### PR TITLE
Fix CI: Install GEOS library for RGeo spatial predicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install GEOS library
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgeos-dev
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Summary
- Fixes failing tests on master branch by installing the GEOS library in CI
- RGeo requires GEOS to support spatial predicates like `intersects?`, `within?`, and `contains?`

## Problem
The CI tests were failing with errors like:
- `RGeo::Error::UnsupportedOperation: Method RGeo::Cartesian::LineStringImpl#intersects? not defined`
- `RGeo::Error::UnsupportedOperation: Method RGeo::Cartesian::PointImpl#within? not defined`

## Solution
Added installation of `libgeos-dev` package in the CI workflow before running tests.

## Test plan
The existing tests should now pass in CI as they do locally where GEOS is installed.