### PR TITLE
feat: Add K-Nearest Neighbor (<->) operator for blazing fast spatial searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ Location.where(
   Location.arel_table[:coordinates].st_distance(point).lt(1000)
 )
 
-# NEW: Advanced spatial predicates
+# NEW: K-Nearest Neighbor - Lightning fast "find nearest" queries
+# Uses spatial index for incredible performance!
+nearest_locations = Location
+  .order(Location.arel_table[:coordinates].distance_operator(my_position))
+  .limit(10)
+
+# Advanced spatial predicates
 # Find intersecting routes
 Route.where(Route.arel_table[:path].st_intersects(restricted_zone))
 
@@ -255,6 +261,7 @@ end
 🔍 **Spatial Query Methods**
 - Core methods: `st_distance`, `st_contains`, `st_within`, `st_length`
 - **NEW:** Advanced spatial operations:
+  - `<->` (distance_operator) - K-Nearest Neighbor search (blazing fast!)
   - `st_intersects` - Detect geometry intersections
   - `st_dwithin` - Efficient proximity queries (index-optimized!)
   - `st_buffer` - Create buffer zones around geometries

--- a/docs/SPATIAL_WARFARE.md
+++ b/docs/SPATIAL_WARFARE.md
@@ -8,6 +8,66 @@ Welcome to the Spatial Warfare Division, pilot. You've been equipped with Active
 
 ## 🎯 The Advanced Weapons Systems
 
+### The <-> Operator - Quantum Targeting System
+
+Before we dive into the standard weapons, let me introduce you to the most powerful targeting system in the fleet: the K-Nearest Neighbor operator, `<->`. While other systems calculate distances in real-time (burning precious CPU cycles), this quantum targeting array uses spatial indexes to lock onto targets at warp speed.
+
+```ruby
+# Traditional targeting (slow, scans entire space)
+NearbyShips.order(
+  Arel.sql("ST_Distance(position, ST_GeomFromText('POINT(-73.5 40.7)', 4326))")
+).limit(10)
+
+# Quantum targeting with <-> (lightning fast, uses spatial index)
+NearbyShips.order(
+  NearbyShips.arel_table[:position].distance_operator(command_ship_position)
+).limit(10)
+
+# Even cleaner with the alias
+NearbyShips.order(
+  NearbyShips.arel_table[:position].send(:'<->', command_ship_position)
+).limit(10)
+
+# Real combat scenario: Find 5 nearest enemy vessels
+class HostileVessel < ActiveRecord::Base
+  scope :nearest_threats, ->(our_position, limit = 5) {
+    order(arel_table[:coordinates].distance_operator(our_position))
+      .limit(limit)
+  }
+  
+  # Emergency evasion: Find escape routes
+  scope :find_escape_vectors, ->(current_position) {
+    safe_zones = SpaceSector.neutral
+      .order(
+        SpaceSector.arel_table[:center_point].distance_operator(current_position)
+      )
+      .limit(3)
+  }
+end
+
+# The Tactical Computer explains:
+# "The <-> operator doesn't calculate distances—it uses the spatial index
+#  to teleport directly to the answer. It's the difference between searching
+#  every star in the galaxy versus knowing exactly which ones are closest."
+```
+
+**Critical Intelligence**: The `<->` operator returns results ordered by distance but doesn't give you the actual distance value. If you need both speed AND distance:
+
+```ruby
+# Get nearest ships with their distances
+Starship
+  .select(
+    "*", 
+    "ST_Distance(position, ST_GeomFromText('#{origin.as_text}', 4326)) as distance_meters"
+  )
+  .order(
+    arel_table[:position].distance_operator(origin)
+  )
+  .limit(10)
+```
+
+## 🎯 Standard Weapons Arsenal
+
 ### ST_Intersects - The Collision Detection Array
 
 Every good pilot knows: space is big, but not big enough when two fleets converge on the same coordinates.

--- a/lib/arel/visitors/postgis.rb
+++ b/lib/arel/visitors/postgis.rb
@@ -36,6 +36,13 @@ module Arel
       end
     end
     class SpatialArea < Unary; end
+    
+    # K-Nearest Neighbor distance operator
+    class SpatialDistanceOperator < Binary
+      def initialize(left, right)
+        super
+      end
+    end
 
     # Wrapper for spatial values that need special handling
     class SpatialValue < Node
@@ -76,6 +83,12 @@ module Arel
       def st_area
         SpatialArea.new(self)
       end
+      
+      def distance_operator(other)
+        SpatialDistanceOperator.new(self, other)
+      end
+      
+      alias :'<->' :distance_operator
     end
   end
 
@@ -116,6 +129,12 @@ module Arel
       def st_area
         Arel::Nodes::SpatialArea.new(self)
       end
+      
+      def distance_operator(other)
+        Arel::Nodes::SpatialDistanceOperator.new(self, other)
+      end
+      
+      alias :'<->' :distance_operator
     end
   end
 
@@ -210,6 +229,12 @@ module Arel
         collector << "ST_Area("
         visit(node.expr, collector)
         collector << ")"
+      end
+      
+      def visit_Arel_Nodes_SpatialDistanceOperator(node, collector)
+        visit(node.left, collector)
+        collector << " <-> "
+        visit_spatial_operand(node.right, collector)
       end
 
       private


### PR DESCRIPTION
## Summary

This PR adds the PostGIS K-Nearest Neighbor (`<->`) operator to the gem, enabling lightning-fast spatial searches that utilize spatial indexes.

## Why This Matters

Traditional "find nearest" queries using `ST_Distance` + `ORDER BY` scan the entire table and calculate distances for every row. The `<->` operator uses spatial indexes to return results orders of magnitude faster.

## Implementation

### New Arel Methods
- `distance_operator(geometry)` - The primary method for KNN searches
- `:<->` alias - For those who prefer symbolic operators

### Usage Examples

```ruby
# Find 10 nearest locations (uses spatial index\!)
Location
  .order(Location.arel_table[:position].distance_operator(my_position))
  .limit(10)

# Find nearest restaurants with actual distances
Restaurant
  .select("*, ST_Distance(location, ST_GeomFromText('#{origin.as_text}', 4326)) as distance")
  .order(Restaurant.arel_table[:location].distance_operator(origin))
  .limit(5)

# Emergency: Find nearest hospitals
Hospital
  .where(emergency_room: true)
  .order(Hospital.arel_table[:coordinates].distance_operator(accident_location))
  .first
```

## Performance Impact

The `<->` operator can be 100-1000x faster than traditional distance queries for large datasets because it uses the spatial index directly rather than calculating distances for every row.

## Documentation

Updated both the technical documentation and the space-themed guides with examples of tactical uses for the KNN operator.

---

That's it folks\! This completes the extraction of custom spatial code I had in my projects. Any additional features can be added via PRs with tests.