### PR TITLE
feat: update to Rails 8.1.0 stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-rails_version = ENV["RAILS_VERSION"] || "8.1.0.beta1"
+rails_version = ENV["RAILS_VERSION"] || "8.1.0"
 gem "railties", "~> #{rails_version}"
 gem "rails", "~> #{rails_version}"
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]

--- a/activerecord-postgis.gemspec
+++ b/activerecord-postgis.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('{lib}/**/*') + [ gemspec, 'LICENSE.txt', 'README.md' ]
   spec.require_paths = [ 'lib' ]
 
-  spec.add_dependency 'activerecord', '>= 8.1.0.beta1', '< 8.2'
+  spec.add_dependency 'activerecord', '>= 8.1.0', '< 8.2'
   spec.add_dependency 'pg'
   spec.add_dependency 'rgeo-activerecord', '>= 8.0'
 end


### PR DESCRIPTION
- Update gemspec to require Rails >= 8.1.0 (removed beta constraint)
- Update Gemfile default Rails version to 8.1.0